### PR TITLE
bypassing captcha by adding headers in the request

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,5 +4,12 @@ var Speaker = require('speaker');
 
 var text = 'Say hello to my little friend';
 
-var url = 'http://translate.google.com/translate_tts?tl=en&q=' + encodeURIComponent(text);
+var url = {
+	url: 'http://translate.google.com/translate_tts?ie=UTF-8&tl=en&client=t&q=' + encodeURIComponent(text),
+	headers: {
+		'User-Agent': 'stagefright/1.2 (Linux;Android 5.0)',
+		'Referer': 'http://translate.google.com/'
+  	}
+};
+
 request(url).pipe(new Lame.Decoder).pipe(new Speaker);


### PR DESCRIPTION
Google has recently implemented a 'Google abuse' feature, making it impossible to send just any regular old HTTP GET. In order to work the Referer and User-agent header should be added to the request along with client=t, get parameter.

http://stackoverflow.com/questions/9893175/google-text-to-speech-api  
