### PR TITLE
Fix typo and clarify where the ENV var is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ git remote add resin git@git.resin.io:username/test.git
 
 You should be able to `git push resin master` to your devices!
 
-You can change the text by setting a `TEXT` environment variable for you app/device.
+You can change the text by setting a `TEXT` environment variable for your app/device in the Resin dashboard.
 
 
 **Note**: If you used an already existing application that you've previously pushed other code


### PR DESCRIPTION
Fix for the typo [mentioned](https://github.com/resin-io/text2speech/pull/3#discussion_r39026225) by @emirotin and a little extra detail on where the env var is set
