### PR TITLE
Temporary fix for npm preinstall running after dependency install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Resin.io -- Simple text-to-speech demo
 
+__FORKED VERSION__ - works around deps.sh being run *after* dependencies are installed on newer npm.
+
 ## How it works
 
 This demo uses Google's Text-To-Speech endpoint to get an MP3 audio stream of the supplied text.

--- a/deps.sh
+++ b/deps.sh
@@ -5,3 +5,6 @@ set -o pipefail
 
 apt-get update
 apt-get install -y alsa-utils libasound2-dev
+
+# Recent node now installs dependencies before running preinstall scripts :(
+npm install speaker@~0.2.6

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "version": "0.0.3",
   "dependencies": {
-    "speaker": "~0.2.4",
     "request": "^2.55.0",
     "lame": "^1.0.2"
   },


### PR DESCRIPTION
Without this speaker module can't be installed without libasound2-dev.
